### PR TITLE
Small fix to tests + benchmarks

### DIFF
--- a/benchmarks/1_1.cpp
+++ b/benchmarks/1_1.cpp
@@ -52,7 +52,8 @@ void test_sync() {
     cirrus::ostore::FullBladeObjectStoreTempl<cirrus::Dummy<SIZE>>
         store(IP, PORT, &client,
             cirrus::serializer_simple<cirrus::Dummy<SIZE>>,
-            cirrus::deserializer_simple<cirrus::Dummy<SIZE>, SIZE>);
+            cirrus::deserializer_simple<cirrus::Dummy<SIZE>,
+                sizeof(cirrus::Dummy<SIZE>)>);
 
     struct cirrus::Dummy<SIZE> d(42);
 

--- a/benchmarks/1_2.cpp
+++ b/benchmarks/1_2.cpp
@@ -34,7 +34,8 @@ void test_async(int N) {
     cirrus::ostore::FullBladeObjectStoreTempl<cirrus::Dummy<SIZE>>
         store(IP, PORT, &client,
             cirrus::serializer_simple<cirrus::Dummy<SIZE>>,
-            cirrus::deserializer_simple<cirrus::Dummy<SIZE>, SIZE>);
+            cirrus::deserializer_simple<cirrus::Dummy<SIZE>,
+                sizeof(cirrus::Dummy<SIZE>)>);
     cirrus::Stats stats;
 
     struct cirrus::Dummy<SIZE> d(42);

--- a/benchmarks/1_3.cpp
+++ b/benchmarks/1_3.cpp
@@ -46,7 +46,8 @@ void test_multiple_clients() {
             cirrus::ostore::FullBladeObjectStoreTempl<cirrus::Dummy<SIZE>>
                 store(IP, PORT, &client,
                     cirrus::serializer_simple<cirrus::Dummy<SIZE>>,
-                    cirrus::deserializer_simple<cirrus::Dummy<SIZE>, SIZE>);
+                    cirrus::deserializer_simple<cirrus::Dummy<SIZE>,
+                        sizeof(cirrus::Dummy<SIZE>)>);
             std::cout << "New thread connected." << std::endl;
             struct cirrus::Dummy<SIZE> d(42);
             // warm up

--- a/tests/mpi/test_mpi.cpp
+++ b/tests/mpi/test_mpi.cpp
@@ -38,7 +38,8 @@ void test_sync() {
     cirrus::ostore::FullBladeObjectStoreTempl<cirrus::Dummy<SIZE>>
         store(IP, PORT, &client,
             cirrus::serializer_simple<cirrus::Dummy<SIZE>>,
-            cirrus::deserializer_simple<cirrus::Dummy<SIZE>, SIZE>);
+            cirrus::deserializer_simple<cirrus::Dummy<SIZE>,
+                sizeof(cirrus::Dummy<SIZE>)>);
     struct cirrus::Dummy<SIZE> d(42);
 
     try {
@@ -91,7 +92,8 @@ void test_sync(int N) {
     cirrus::ostore::FullBladeObjectStoreTempl<cirrus::Dummy<SIZE>>
         store(IP, PORT, &client,
             cirrus::serializer_simple<cirrus::Dummy<SIZE>>,
-            cirrus::deserializer_simple<cirrus::Dummy<SIZE>, SIZE>);
+            cirrus::deserializer_simple<cirrus::Dummy<SIZE>,
+                sizeof(cirrus::Dummy<SIZE>)>);
     cirrus::Stats stats;
 
     struct cirrus::Dummy<SIZE> d(42);

--- a/tests/object_store/mem_exhaustion.cpp
+++ b/tests/object_store/mem_exhaustion.cpp
@@ -25,7 +25,8 @@ void test_exhaustion() {
     cirrus::ostore::FullBladeObjectStoreTempl<cirrus::Dummy<SIZE>>
         store(IP, PORT, &client,
                 cirrus::serializer_simple<cirrus::Dummy<SIZE>>,
-                cirrus::deserializer_simple<cirrus::Dummy<SIZE>, SIZE>);
+                cirrus::deserializer_simple<cirrus::Dummy<SIZE>,
+                    sizeof(cirrus::Dummy<SIZE>)>);
     struct cirrus::Dummy<SIZE> d(42);
 
     std::cout << "Putting one million objects" << std::endl;

--- a/tests/object_store/test_fullblade_store.cpp
+++ b/tests/object_store/test_fullblade_store.cpp
@@ -33,7 +33,7 @@ void test_sync() {
                       &client,
                       cirrus::serializer_simple<cirrus::Dummy<SIZE>>,
                       cirrus::deserializer_simple<cirrus::Dummy<SIZE>,
-                      sizeof(cirrus::Dummy<SIZE>)>);
+                        sizeof(cirrus::Dummy<SIZE>)>);
 
     struct cirrus::Dummy<SIZE> d(42);
 
@@ -60,7 +60,7 @@ void test_sync(int N) {
                 &client,
                 cirrus::serializer_simple<cirrus::Dummy<SIZE>>,
                 cirrus::deserializer_simple<cirrus::Dummy<SIZE>,
-                sizeof(cirrus::Dummy<SIZE>)>);
+                    sizeof(cirrus::Dummy<SIZE>)>);
 
     cirrus::Stats stats;
 

--- a/tests/object_store/test_iterator.cpp
+++ b/tests/object_store/test_iterator.cpp
@@ -67,7 +67,7 @@ void test_iterator_alt() {
             &client,
             cirrus::serializer_simple<cirrus::Dummy<SIZE>>,
             cirrus::deserializer_simple<cirrus::Dummy<SIZE>,
-            sizeof(cirrus::Dummy<SIZE>)>);
+                sizeof(cirrus::Dummy<SIZE>)>);
 
     cirrus::LRAddedEvictionPolicy policy(10);
     cirrus::CacheManager<cirrus::Dummy<SIZE>> cm(&store, &policy, 10);

--- a/tests/object_store/test_mt.cpp
+++ b/tests/object_store/test_mt.cpp
@@ -23,7 +23,8 @@ cirrus::TCPClient client;
 cirrus::ostore::FullBladeObjectStoreTempl<cirrus::Dummy<SIZE>> store(IP, PORT,
                     &client,
                     cirrus::serializer_simple<cirrus::Dummy<SIZE>>,
-                    cirrus::deserializer_simple<cirrus::Dummy<SIZE>, SIZE>);
+                    cirrus::deserializer_simple<cirrus::Dummy<SIZE>,
+                        sizeof(cirrus::Dummy<SIZE>)>);
 
 /**
   * Tests that behavior is as expected when multiple threads make get and put

--- a/tests/object_store/test_mult_clients.cpp
+++ b/tests/object_store/test_mult_clients.cpp
@@ -40,8 +40,9 @@ void test_multiple_clients() {
           cirrus::TCPClient client;
           cirrus::ostore::FullBladeObjectStoreTempl<cirrus::Dummy<SIZE>>
               store(IP, PORT, &client,
-                       cirrus::serializer_simple<cirrus::Dummy<SIZE>>,
-                       cirrus::deserializer_simple<cirrus::Dummy<SIZE>, SIZE>);
+                        cirrus::serializer_simple<cirrus::Dummy<SIZE>>,
+                        cirrus::deserializer_simple<cirrus::Dummy<SIZE>,
+                            sizeof(cirrus::Dummy<SIZE>)>);
 
           for (int i = 0; i < 100; ++i) {
                 int rnd = std::rand();


### PR DESCRIPTION
Just a small fix. This makes it so that one of the errors in `test_mt` and `test_mult_clients` is eliminated, and also fixes the error everywhere else it occurs. Make check and cpplint both pass.

The issue was that only part of the Dummy struct was being copied, rather than the entire struct.