### PR TITLE
Moved RDMA library includes to proper locations

### DIFF
--- a/benchmarks/Makefile.am
+++ b/benchmarks/Makefile.am
@@ -3,14 +3,14 @@ AUTOMAKE_OPTIONS = foreign
 bin_PROGRAMS = 	1_1 1_3 throughput #TODO(Tyler): add 1_2 as it requires async later
 
 LIBS         = 	-l:libcityhash.a -lclient \
-               	-lauthentication -lutils -lcommon
+               	-lauthentication -lutils -lcommon \
+		$(LIBRDMACM) $(LIBIBVERBS)
 
 LINCLUDES    = 	-L$(top_srcdir)/src/utils/ \
 		-L$(top_srcdir)/src/client/ \
 		-L$(top_srcdir)/src/authentication \
 		-L$(top_srcdir)/src/common \
-		-L$(top_srcdir)/third_party/libcuckoo/cityhash-1.1.1/src/.libs/ \
-		$(LIBRDMACM) $(LIBIBVERBS)
+		-L$(top_srcdir)/third_party/libcuckoo/cityhash-1.1.1/src/.libs/
 
 1_1_SOURCES  = 	1_1.cpp
 1_1_LDFLAGS  = 	-pthread

--- a/src/client/Makefile.am
+++ b/src/client/Makefile.am
@@ -6,7 +6,8 @@ AUTOMAKE_OPTIONS = foreign
 
 SOURCES = TCPClient.cpp
 LIBS    = -l:libcityhash.a -lclient -L../utils/ -lutils -L../authentication/ -lauthentication \
-	  -L../common/ -lcommon -L. -L$(top_srcdir)/third_party/libcuckoo/cityhash-1.1.1/src/.libs/
+	  -L../common/ -lcommon -L. -L$(top_srcdir)/third_party/libcuckoo/cityhash-1.1.1/src/.libs/ \
+	  $(LIBRDMACM) $(LIBIBVERBS)
 
 if USE_RDMA
 SOURCES += RDMAClient.cpp


### PR DESCRIPTION
Fixes #97 . Just a small fix moving the location of the includes, I think this had been done on some other branch but it's important to have so master can actually run the throughput benchmark with RDMA. Makefiles were aligned with nano.