### PR TITLE
Fix to memory leak when exception thrown

### DIFF
--- a/src/client/BladeClient.h
+++ b/src/client/BladeClient.h
@@ -14,6 +14,7 @@ using ObjectID = uint64_t;
   */
 class BladeClient {
  public:
+    virtual ~BladeClient() {}
     virtual void connect(const std::string& address,
                          const std::string& port) = 0;
 

--- a/src/client/TCPClient.h
+++ b/src/client/TCPClient.h
@@ -21,16 +21,16 @@ using TxnID = uint64_t;
   */
 class TCPClient : public BladeClient {
  public:
-    virtual ~TCPClient();
+    ~TCPClient() override;
     void connect(const std::string& address,
         const std::string& port) override;
 
     bool write_sync(ObjectID oid, const void* data, uint64_t size) override;
     bool read_sync(ObjectID oid, void* data, uint64_t size) override;
 
-    virtual cirrus::Future write_async(ObjectID oid, const void* data,
+    cirrus::Future write_async(ObjectID oid, const void* data,
                                        uint64_t size);
-    virtual cirrus::Future read_async(ObjectID oid, void* data, uint64_t size);
+    cirrus::Future read_async(ObjectID oid, void* data, uint64_t size);
 
     bool remove(ObjectID id) override;
 

--- a/src/object_store/FullBladeObjectStore.h
+++ b/src/object_store/FullBladeObjectStore.h
@@ -112,16 +112,14 @@ T FullBladeObjectStoreTempl<T>::get(const ObjectID& id) const {
     }
     /* This allocation provides a buffer to read the serialized object
        into. */
-    void* ptr = ::operator new (serialized_size);
+    std::unique_ptr<char[]> ptr(new char[serialized_size]);
 
     // Read into the section of memory you just allocated
-    client->read_sync(id, ptr, serialized_size);
+    client->read_sync(id, ptr.get(), serialized_size);
 
     // Deserialize the memory at ptr and return an object
-    T retval = deserializer(ptr, serialized_size);
+    T retval = deserializer(ptr.get(), serialized_size);
 
-    // Free the memory we stored the serialized object in.
-    ::operator delete (ptr);
     return retval;
 }
 


### PR DESCRIPTION
Fixes #113 and includes the same fix for #112 as #114 .

Fixed the memory leak by making use of a smart pointer so that if an exception is thrown, the buffer is automatically freed. cpplint and make check pass (save for the rdma mt bug but an issue is open for that)