### PR TITLE
Convert to locks

### DIFF
--- a/src/client/RDMAClient.h
+++ b/src/client/RDMAClient.h
@@ -91,7 +91,7 @@ class RDMAClient : public BladeClient {
                     throw std::runtime_error("BUG");
                 result = std::make_shared<bool>();
                 result_available = std::make_shared<bool>(false);
-                op_sem = std::make_shared<cirrus::SpinLock>();
+                op_sem = std::make_shared<cirrus::PosixSemaphore>();
                 error_code = std::make_shared<cirrus::ErrorCodes>();
             }
 


### PR DESCRIPTION
Fixes #129 . This PR converts all the semaphores to SpinLocks save for the semaphore guarding the send queue (when this one was changed things would hang on occasion).

Passes make check and cpplint, and it does seem that there is a slight speed improvement over master.

It actually seems that this may break the RDMA side of things (errors with status messages not being IBV_WC_SUCCESS, status is instead "4"). We'll want to hold off on doing much more with this until that is resolved.