### PR TITLE
Fix to makefile refactoring PR

### DIFF
--- a/tests/client/Makefile.am
+++ b/tests/client/Makefile.am
@@ -17,9 +17,9 @@ bin_PROGRAMS += rdmaclientmain
 endif
 
 CPPFLAGS = -ggdb -I$(top_srcdir) $(DEFINE_LOG) \
-						  -I$(top_srcdir)/third_party/flatbuffers/include \
-						  -I$(top_srcdir)/src \
-						  -isystem $(top_srcdir)/third_party/libcuckoo/
+	   -I$(top_srcdir)/third_party/flatbuffers/include \
+	   -I$(top_srcdir)/src \
+	   -isystem $(top_srcdir)/third_party/libcuckoo/
 LDFLAGS = -pthread
 
 LDADD = $(LIBS) $(LINCLUDES)


### PR DESCRIPTION
For some reason the refactoring of the makefiles broke compilation on firebox. This commit fixes that, but I'm not sure why as it looks near identical. 

To fix things, I reverted to the original `tests/client/Makefile.am` then stripped parts away until I was left with something resembling the present (broken) version, though it is able to compile.