### PR TITLE
Deferred Writes

### DIFF
--- a/src/cache_manager/CacheManager.h
+++ b/src/cache_manager/CacheManager.h
@@ -18,6 +18,8 @@
 namespace cirrus {
 using ObjectID = uint64_t;
 
+const uint64_t HIGH_PEND = 50;
+
 /**
  * A class that manages the cache and interfaces with the store.
  */
@@ -453,7 +455,7 @@ void CacheManager<T>::evict(ObjectID oid) {
 
             // Clean the pending writes map if too full by
             // removing all operations that have completed
-            if (pending_writes.size() > 50) {
+            if (pending_writes.size() > HIGH_PEND) {
                 for (auto it = pending_writes.begin();
                     it != pending_writes.end(); it++) {
                     auto future = it->second;

--- a/src/client/RDMAClient.cpp
+++ b/src/client/RDMAClient.cpp
@@ -10,6 +10,7 @@
 #include <atomic>
 #include <random>
 #include <cassert>
+#include <utility>
 
 #include "client/RDMAClient.h"
 #include "utils/utils.h"
@@ -1014,7 +1015,6 @@ bool RDMAClient::rdma_read_sync(const AllocationRecord& alloc_rec,
                 alloc_rec.remote_addr + offset,
                 alloc_rec.peer_rkey, mem);
     } else {
-
         // XXX fix this
         read_rdma_sync(id_, length,
                 alloc_rec.remote_addr + offset,

--- a/src/client/RDMAClient.h
+++ b/src/client/RDMAClient.h
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <utility>
 #include <stdexcept>
 
 #include "common/ThreadPinning.h"
@@ -46,7 +47,7 @@ struct GeneralContext {
     struct ibv_qp_init_attr qp_attr;
     std::thread* cq_poller_thread;
 };
-    
+
 /**
  * A struct representing a portion of RDMA memory.
  */
@@ -104,7 +105,7 @@ struct RDMAMem {
     bool clear() {
         if (registered_ == false)
             throw std::runtime_error("Not registered");
-        
+
         LOG<INFO>("prepare:: ibv_dereg_mr()", addr_,
                 "length: ", size_);
 
@@ -119,11 +120,11 @@ struct RDMAMem {
         return default_;
     }
 
-    uint64_t addr_ = 0; //< Address of the memory */
-    uint64_t size_ = 0; //< Size of the memory */
-    struct ibv_mr *mr = 0; //< Pointer to ibv_mr for this memory */
-    bool registered_ = false; //< If the memory is registered. */
-    bool cleared_    = false; //< If the memory is cleared. */
+    uint64_t addr_ = 0;  //< Address of the memory */
+    uint64_t size_ = 0;  //< Size of the memory */
+    struct ibv_mr *mr = 0;  //< Pointer to ibv_mr for this memory */
+    bool registered_ = false;  //< If the memory is registered. */
+    bool cleared_    = false;  //< If the memory is cleared. */
 
     // Indicates whether this RDMAMem was constructed by default
     // (because user did not provide one)
@@ -211,7 +212,7 @@ class RDMAClient : public BladeClient {
             fd->result_available = true;
             fd->result = true;
         }
-  
+
         // ptr to data. Delete'd for RDMA_WRITEs
         char* data = nullptr;
         struct rdma_cm_id* id;

--- a/tests/object_store/test_cache_manager.cpp
+++ b/tests/object_store/test_cache_manager.cpp
@@ -512,8 +512,11 @@ void test_bulk_nonexistent() {
 void test_deferred_writes() {
     std::unique_ptr<cirrus::BladeClient> client =
         cirrus::test_internal::GetClient(use_rdma_client);
-    cirrus::ostore::FullBladeObjectStoreTempl<int> store(IP, PORT, client.get(),
-            cirrus::serializer_simple<int>,
+
+    cirrus::serializer_simple<int> serializer;
+    cirrus::ostore::FullBladeObjectStoreTempl<int> store(
+            IP, PORT, client.get(),
+            serializer,
             cirrus::deserializer_simple<int, sizeof(int)>);
 
     cirrus::LRAddedEvictionPolicy policy(2);


### PR DESCRIPTION
fixes #151 . Passes new test written for it as well as cpplint.

The design is as follows:
* New argument added to constructor for cache manager. By default writes are not deferred, but they can be specified to be deferred.
* If writes are deferred, the item is not put to the remote store until evicted. This is achieved via an asynchronous write, and a map keeps track of the future.
* When a read is performed, the cache manager checks the map to see if there is an ongoing asynchronous operation for that id. If so, it waits for it to complete before the read can proceed.
* Completed operation are cleared from the map either if an eviction attempts to increase the size of the map over 50, or when a `get()` is made on an id that was evicted.