### PR TITLE
ErrorTask with pub/sub (tested with 20 workers and working)

### DIFF
--- a/examples/ml/ErrorTask.cpp
+++ b/examples/ml/ErrorTask.cpp
@@ -5,9 +5,107 @@
 #include "config.h"
 #include "S3Iterator.h"
 #include "Utils.h"
+#include "async.h"
+#include "adapters/libevent.h"
 
+#define DEBUG
 #define ERROR_INTERVAL_USEC (500) // time between error checks
 
+/**
+  * Ugly but necessary for now
+  * both onMessage and ErrorTask need access to this
+  */
+namespace ErrorTaskGlobal {
+  std::mutex model_lock;
+  std::unique_ptr<LRModel> model;
+  std::unique_ptr<lr_model_deserializer> lmd;
+  volatile bool model_is_here = true;
+}
+/**
+  * Works as a cache for remote model
+  */
+class ModelProxyErrorTask {
+  public:
+    ModelProxyErrorTask(auto redis_ip, auto redis_port, uint64_t mgs) :
+      redis_ip(redis_ip), redis_port(redis_port), base(event_base_new())
+    { 
+      ErrorTaskGlobal::model.reset(new LRModel(mgs));
+      ErrorTaskGlobal::lmd.reset(new lr_model_deserializer(mgs));
+    }
+
+    static void connectCallback(const redisAsyncContext*, int) {
+      std::cout << "connectCallback" << std::endl;
+    }
+
+    static void disconnectCallback(const redisAsyncContext*, int) {
+      std::cout << "disconnectCallback" << std::endl;
+    }
+
+    LRModel get_model() {
+      std::cout << "get_model" << std::endl;
+      // wait until first model has arrived
+      while (ErrorTaskGlobal::model_is_here == true) {
+      }
+
+      ErrorTaskGlobal::model_lock.lock();
+      LRModel ret = *ErrorTaskGlobal::model;
+      ErrorTaskGlobal::model_lock.unlock();
+      return ret;
+    }
+
+    static void onMessage(redisAsyncContext*, void *reply, void*) {
+      redisReply *r = reinterpret_cast<redisReply*>(reply);
+
+      printf("onMessage\n");
+      if (r->type == REDIS_REPLY_ARRAY) {
+        const char* str = r->element[2]->str;
+        uint64_t len = r->element[2]->len;
+
+        printf("len: %lu\n", len);
+
+        // XXX fix this. Should have some way to check if it's a model update
+        if (len > 100) {
+          printf("Updating model at time: %lu\n", get_time_us());
+          ErrorTaskGlobal::model_lock.lock();
+          *ErrorTaskGlobal::model = ErrorTaskGlobal::lmd->operator()(str, len);
+          ErrorTaskGlobal::model_lock.unlock();
+          ErrorTaskGlobal::model_is_here = false;
+        }
+      } else {
+        throw std::runtime_error("Not an array");
+      }
+    }
+
+    void thread_fn() {
+      std::cout << "connecting to redis.." << std::endl;
+      redisAsyncContext* model_r = redis_async_connect(redis_ip.c_str(), redis_port);
+      std::cout << "connected to redis.." << model_r << std::endl;
+      if (!model_r) {
+        throw std::runtime_error("Error connecting to redis");
+      }
+      
+      std::cout << "ErrorTask: libevent attach" << std::endl;
+      redisLibeventAttach(model_r, base);
+      redis_connect_callback(model_r, connectCallback);
+      redis_disconnect_callback(model_r, disconnectCallback);
+      redis_subscribe_callback(model_r, onMessage, "model");
+      
+      std::cout << "eventbase dispatch" << std::endl;
+      event_base_dispatch(base);
+    }
+
+    void run() {
+      thread = std::make_unique<std::thread>(
+          std::bind(&ModelProxyErrorTask::thread_fn, this));
+    }
+
+  private:
+    std::string redis_ip;
+    int redis_port;
+
+    struct event_base *base;
+    std::unique_ptr<std::thread> thread;
+};
 
 #if defined(USE_REDIS)
 LRModel ErrorTask::get_model_redis(auto r, auto lmd) {
@@ -87,6 +185,9 @@ void ErrorTask::run(const Configuration& config) {
   }
 
   wait_for_start(ERROR_TASK_RANK, r, nworkers);
+
+  ModelProxyErrorTask mp(REDIS_IP, REDIS_PORT, MODEL_GRAD_SIZE);
+  mp.run();
 #endif
 
   // get data first
@@ -136,7 +237,6 @@ loop_accuracy:
   while (1) {
     usleep(ERROR_INTERVAL_USEC); //
 
-    //double loss = 0;
     try {
       // first we get the model
 #ifdef DEBUG
@@ -145,25 +245,19 @@ loop_accuracy:
         << "\n";
 #endif
       LRModel model(MODEL_GRAD_SIZE);
-#ifdef USE_CIRRUS
-      model = model_store.get(MODEL_BASE);
-#elif defined(USE_REDIS)
-      model = get_model_redis(r, lmd);
-#endif
+      model = mp.get_model();
 
 #ifdef DEBUG
       std::cout << "[ERROR_TASK] received the model with id: "
         << MODEL_BASE << "\n";
 #endif
-      std::cout << "[ERROR_TASK] computing loss time(ms): " << get_time_ms() 
+      std::cout << "[ERROR_TASK] computing loss time(us): " << get_time_us() 
         << std::endl;
       model.calc_loss(dataset);
     } catch(const cirrus::NoSuchIDException& e) {
       std::cout << "run_compute_error_task unknown id" << std::endl;
     }
   }
-
-  //std::cout << "Learning loss (avg per sample): " << loss << std::endl;
 }
 
 void ErrorTask::unpack_minibatch(
@@ -180,8 +274,6 @@ void ErrorTask::unpack_minibatch(
     double* data = minibatch.get() + j * (features_per_sample + 1);
     labels.get()[j] = *data;
 
-    //std::cout << "j: " << j << std::endl;
-    //std::cout << "features_per_sample: " << features_per_sample << std::endl;
     if (!FLOAT_EQ(*data, 1.0) && !FLOAT_EQ(*data, 0.0))
       throw std::runtime_error(
           "Wrong label in unpack_minibatch " + std::to_string(*data));

--- a/examples/ml/S3Iterator.cpp
+++ b/examples/ml/S3Iterator.cpp
@@ -109,6 +109,7 @@ void S3Iterator::thread_function() {
     std::cout << "Getting object. count: " << count++ << std::endl;
 
     std::string s3_obj;
+try_start:
     try {
       std::chrono::steady_clock::time_point start =
         std::chrono::steady_clock::now();
@@ -126,6 +127,7 @@ void S3Iterator::thread_function() {
         << std::endl;
     } catch(...) {
       std::cout << "S3Iterator: error in s3_get_object" << std::endl;
+      goto try_start;
       exit(-1);
     }
     

--- a/examples/ml/Tasks.h
+++ b/examples/ml/Tasks.h
@@ -153,10 +153,13 @@ class PSTask : public MLTask {
     void run(const Configuration& config);
 
   private:
+    auto connect_redis();
+
+    void put_model(LRModel model);
+    void publish_model(const LRModel& model);
+
     void update_gradient_version(
         auto& gradient, int worker, LRModel& model, Configuration config);
-    auto connect_redis();
-    void put_model(LRModel model);
     void get_gradient(auto r, auto& gradient, auto gradient_id);
 
     void thread_fn();


### PR DESCRIPTION
PR does a few things

1. Makes ErrorTask get model updates with pub/sub. The latest model received is used to compute the accuracy every X seconds.
2. Retry whenever there is an S3 error in the main loop of the S3Iterator
3. Some code refactoring